### PR TITLE
Use Embedded Thumbnails

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ For enhanced file previews (with `scope.sh`):
 * `img2txt` (from `caca-utils`) for ASCII-art image previews
 * `w3mimgdisplay`, `ueberzug`, `mpv`, `iTerm2`, `kitty`, `terminology` or `urxvt` for image previews
 * `convert` (from `imagemagick`) to auto-rotate images and for SVG previews
-* `ffmpegthumbnailer` for video thumbnails
+* `ffmpeg`, or `ffmpegthumbnailer` for video thumbnails
 * `highlight`, `bat` or `pygmentize` for syntax highlighting of code
 * `atool`, `bsdtar`, `unrar` and/or `7z` to preview archives
 * `bsdtar`, `tar`, `unrar`, `unzip` and/or `zipinfo` (and `sed`) to preview

--- a/doc/ranger.1
+++ b/doc/ranger.1
@@ -310,7 +310,7 @@ are automatically used when available but completely optional.
 .IP "\-" 2
 \&\f(CW\*(C`convert\*(C'\fR (from \f(CW\*(C`imagemagick\*(C'\fR) to auto-rotate images and for \s-1SVG\s0 previews
 .IP "\-" 2
-\&\f(CW\*(C`ffmpegthumbnailer\*(C'\fR for video thumbnails
+\&\f(CW\*(C`ffmpeg\*(C'\fR or \f(CW\*(C`ffmpegthumbnailer\*(C'\fR for video thumbnails
 .IP "\-" 2
 \&\f(CW\*(C`highlight\*(C'\fR, \f(CW\*(C`bat\*(C'\fR or \f(CW\*(C`pygmentize\*(C'\fR for syntax highlighting of code
 .IP "\-" 2

--- a/ranger/data/scope.sh
+++ b/ranger/data/scope.sh
@@ -155,7 +155,9 @@ handle_image() {
 
         ## Video
         # video/*)
-        #     # Thumbnail
+        #     # Get embedded thumbnail
+        #     ffmpeg -i "${FILE_PATH}" -map 0:v -map -0:V -c copy "${IMAGE_CACHE_PATH}" && exit 6
+        #     # Get frame 10% into video
         #     ffmpegthumbnailer -i "${FILE_PATH}" -o "${IMAGE_CACHE_PATH}" -s 0 && exit 6
         #     exit 1;;
 


### PR DESCRIPTION
<!-- Provide a descriptive summary of the changes in the title above -->

#### ISSUE TYPE
<!-- Pick relevant types and delete the rest -->
- Improvement/feature implementation

#### RUNTIME ENVIRONMENT
<!-- Details of your runtime environment -->
<!-- Retrieve Python/ranger version and locale with `ranger -\-version` -->
- Operating system and version: Arch Linux 5.13.9-arch1-1
- Terminal emulator and version: Alacritty 0.9.0
- Python version: 3.9.6
- Ranger version/commit: 1.9.3
- Locale: en_US.UTF-8

#### CHECKLIST
<!-- All [REQUIRED] requisites need to be fulfilled -->
<!-- Replace [ ] with [X] when fulfilled -->
- [X] The `CONTRIBUTING` document has been read **[REQUIRED]**
- [X] All changes follow the code style **[REQUIRED]**
- [X] All new and existing tests pass **[REQUIRED]**
- [ ] Changes require config files to be updated
    - [ ] Config files have been updated
- [X] Changes require documentation to be updated
    - [ ] Documentation has been updated
- [ ] Changes require tests to be updated
    - [ ] Tests have been updated

#### DESCRIPTION
<!-- Describe the changes in detail -->
Use ffmpeg to get embedded thumbnails. As far as I know this is only supported by mp4 videos. The code is commented out because it requires ffmpeg. It is placed before ffmpegthumbnailer because it is likely more relevant.

#### MOTIVATION AND CONTEXT
<!-- Why are these changes required? -->
I use youtube-dl and I like having the thumbnail because it is more useful than a random frame from 10% into the video. I use `--embed-thumbnail` when the video is mp4 to have less files. This lets me have image previews of the thumbnail.
<!-- What problems do these changes solve? -->
<!-- Link to relevant issues -->


#### TESTING
<!-- What tests have been run? -->
<!-- How does the changes affect other areas of the codebase? -->


#### IMAGES / VIDEOS<!-- Only if relevant -->
<!-- Link or embed images and videos of screenshots, sketches etc. -->
